### PR TITLE
Add JUMBF and CBOR embedding support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pyyaml",
     "cryptography",
     "deprecated",
+    "cbor2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- implement `SerializationFormat` enum and support JSON, CBOR and JUMBF serialization
- add auto-detection logic for decoding outer payload bytes
- update `embed_metadata` and streaming handler to accept serialization format
- add tests for new formats
- add `cbor2` dependency

## Testing
- `black encypher tests --line-length 150`
- `pytest -q`